### PR TITLE
Bubble sort issues

### DIFF
--- a/homeTask/bubbleSort/Program.cs
+++ b/homeTask/bubbleSort/Program.cs
@@ -1,5 +1,4 @@
 ﻿int[] elements = { 800, 11, 50, 771, 649, 770, 240, 9 };
-
 int length = elements.Length;
 
 void bubbleSort(int[] arr)
@@ -9,6 +8,7 @@ void bubbleSort(int[] arr)
     for(int i = 0; i < length; i++)
     {
         swapped = false;
+
         for(int j = 0; j < length - 1 - i; j++)
         {
             if(elements[j] > elements[j + 1])

--- a/homeTask/bubbleSort/Program.cs
+++ b/homeTask/bubbleSort/Program.cs
@@ -1,32 +1,22 @@
 ﻿int[] elements = { 800, 11, 50, 771, 649, 770, 240, 9 };
+
 int length = elements.Length;
 
-void bubbleSort(int[] arr)
+int loopIterations = 0;
+
+for(int i = 0; i < length; i++)
 {
-    bool swapped;
 
-    for(int i = 0; i < length; i++)
+    for(int j = 0; j < length - 1 - i; j++)
     {
-        swapped = false;
-
-        for(int j = 0; j < length - 1 - i; j++)
+        if(elements[j] > elements[j + 1])
         {
-            if(elements[j] > elements[j + 1])
-            {
-                swapped = true;
-
-                elements[j] = elements[j] + elements[j + 1];
-                elements[j + 1] = elements[j] - elements[j + 1];
-                elements[j] = elements[j] - elements[j + 1];
-            }
-        }
-
-        if(!swapped)
-        {
-            break;
+            (elements[j], elements[j + 1]) = (elements[j + 1], elements[j]);
+            Console.WriteLine(String.Join(" ", elements));
+            loopIterations++;
         }
     }
 }
 
-bubbleSort(elements);
 Console.WriteLine(String.Join(" ", elements));
+Console.WriteLine(loopIterations);

--- a/homeTask/bubbleSort/Program.cs
+++ b/homeTask/bubbleSort/Program.cs
@@ -1,22 +1,23 @@
 ﻿int[] elements = { 800, 11, 50, 771, 649, 770, 240, 9 };
 
 int length = elements.Length;
+int i = 0;
 
-int loopIterations = 0;
+bool swapped = true;
 
-for(int i = 0; i < length; i++)
+while(swapped)
 {
+    swapped = false;
 
     for(int j = 0; j < length - 1 - i; j++)
     {
         if(elements[j] > elements[j + 1])
         {
             (elements[j], elements[j + 1]) = (elements[j + 1], elements[j]);
-            Console.WriteLine(String.Join(" ", elements));
-            loopIterations++;
+            swapped = true;
         }
     }
+    i++;
 }
 
 Console.WriteLine(String.Join(" ", elements));
-Console.WriteLine(loopIterations);

--- a/homeTask/bubbleSort/bubbleSort.sln
+++ b/homeTask/bubbleSort/bubbleSort.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bubbleSort", "bubbleSort.csproj", "{840F6650-4B12-419A-98C9-8E82BDC17358}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BubbleSort", "BubbleSort.csproj", "{840F6650-4B12-419A-98C9-8E82BDC17358}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/homeTask/shapes/CShape.cs
+++ b/homeTask/shapes/CShape.cs
@@ -1,0 +1,6 @@
+﻿namespace lesson2;
+
+public class shapes
+{
+    
+}


### PR DESCRIPTION
Избавился от функции
Убрал флаг swapped
Добавил вывод в консоль кол-ва итераций и состояние массива на каждой итерации

Не понимаю куда еще лучше сделать сортировку. Для чего нужен while swapped, если во втором цикле
` for(int j = 0; j < length - 1 - i; j++)` `length - 1 - i` кол-во проходов уменьшаю после перемещенного эл-а

Проверил "на листочке" и если модифицировать сортировку, то получится уже другая
`int[] elements = { 800, 11, 50, 771, 649, 770, 240, 9 };

int length = elements.Length;

int loopIterations = 0;

for(int i = 0; i < length; i++)
{

    for(int j = 0; j < length - 1 - i; j++)
    {
        if(elements[j] > elements[j + 1])
        {
            (elements[j], elements[j + 1]) = (elements[j + 1], elements[j]);
            Console.WriteLine(String.Join(" ", elements));
            loopIterations++;
            Console.WriteLine($"loopIterations {loopIterations}");
        }
    }
    Console.WriteLine($"iterations {i}");
}`